### PR TITLE
Reduce noisy log entries

### DIFF
--- a/include/main.php
+++ b/include/main.php
@@ -44,12 +44,12 @@ switch($type){
 \gp\tool\Plugins::Action('PageCreated');
 
 if (session_status() == PHP_SESSION_NONE) {
-        error_log("No active session detected. Attempting session_start()...");
+        //error_log("No active session detected. Attempting session_start()...");
 		if (!session_start()) {
             error_log("session_start() FAILED.");
 			die("Session could not be started.");
         } else {
-            error_log("session_start() SUCCEEDED. Session ID: " . session_id());
+            //error_log("session_start() SUCCEEDED. Session ID: " . session_id());
         }
     }
 


### PR DESCRIPTION
This patch comments two lines which insert two log entries into the webserver logs with **every single request**:

```
[Thu Jun 05 22:22:17.409203 2025] [php:notice] [pid 1286332:tid 1286332] [client 192.168.122.1:33886] No active session detected. Attempting session_start()..., referer: http://test.com/index.php/Admin/Uploaded
[Thu Jun 05 22:22:17.409587 2025] [php:notice] [pid 1286332:tid 1286332] [client 192.168.122.1:33886] session_start() SUCCEEDED. Session ID: sfatjre9icd851eatlui277p54, referer: http://test.com/index.php/Admin/Uploaded
```

There is no need to notify a user who has turned notices off that the code is functioning as intended; only report errors.